### PR TITLE
Add enable and debug options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,8 @@ module.exports = {
         ],
         formatOptions: {
             rpConfig: {
+                enable: true,
+                debug: false,
                 token: 'your token',
                 endpoint: 'https://your-rp-instance/api/v1',
                 description: 'Description',
@@ -27,3 +29,4 @@ module.exports = {
     }
 }
 ```
+Option `enable` is set to `true` even if it is not defined explicitly in rpConfig section.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ class RPFormatter extends Formatter {
 
     constructor(options) {
         super(options);
+        const rpEnable = options.parsedArgvOptions.rpConfig.enable;
+        if (rpEnable !== undefined && !rpEnable) return undefined;
         options.eventBroadcaster.on('envelope', this.processEnvelope.bind(this));
         this.rpConfig = options.parsedArgvOptions.rpConfig;
         this.rpClient = new RPClient(this.rpConfig);
@@ -28,7 +30,8 @@ class RPFormatter extends Formatter {
             startTime: this.rpClient.helpers.now(),
             description: this.rpConfig.description,
             attributes: this.rpConfig.tags,
-            mode: this.rpConfig.mode
+            mode: this.rpConfig.mode,
+            debug: this.rpConfig.debug
         });
 
         this.launchId = launchObj.tempId;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qavajs/format-report-portal",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "cucumber formatter for report portal",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Add support for `enable` and `debug` parameters in RP config.
To enable/disable execution set `enable` to true or false respectively.
To enable/disable debug option (print debug info to console) set `debug` to true or false respectively.