### PR TITLE
rpConfig parameter to define a place for tags: attributes or description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+Before submitting this PR, please ensure that you have completed the following:
+
+- [ ] Updated the CHANGELOG.md.
+- [ ] Updated the `packages.json` if necessary.
+- [ ] Checked that there aren't other open pull requests for the same issue/update.
+- [ ] Checked that your contribution follows the project's contribution guidelines.
+
+## Description
+
+Please describe your changes and any new features you're introducing, or issues you're fixing.
+
+### Related Issues
+
+Please link any related issues or bug reports that this PR will address.
+
+---
+
+Thank you for your contribution! 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,6 @@
+## 0.14.0
+- added config parameter for placing tags to attributes or description (default)
+
 ## 0.13.2
 - updated version to 0.13.2
 - pull request template added to reduce human factor

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.13.2
+- updated version to 0.13.2
+- pull request template added to reduce human factor
+
 ## 0.13.1
 - fixed a missed bracket
 

--- a/README.MD
+++ b/README.MD
@@ -26,7 +26,8 @@ module.exports = {
                 mode: 'DEFAULT',
                 retry: 1, // number of retries to send result to report portal (default - 1)
                 ignoreErrors: false, // ignore RP errors (default: false)
-                showLaunchURL: true // log report portal launch link
+                showLaunchURL: true // log report portal launch link,
+                tagsAsAttributes: true // (default: false → tags go to description)
             },
         }
     }

--- a/index.js
+++ b/index.js
@@ -84,11 +84,10 @@ class RPFormatter extends Formatter {
         if (!this.features[featureName]) {
             await retry(async () => {
                 const featureItem = this.rpClient.startTestItem({
-                    attributes: this.prepareTags(testCase.gherkinDocument.feature.tags),
+                    attributes: this.rpConfig.tagsAsAttributes ? this.prepareTags(testCase.gherkinDocument.feature.tags) : [],
                     description:
-                        this.formatTags(testCase.gherkinDocument.feature.tags) +
-                        '\n' +
-                        testCase.gherkinDocument.feature.description,
+                        this.rpConfig.tagsAsAttributes ? '' : `${this.formatTags(testCase.gherkinDocument.feature.tags)}\n`
+                        + testCase.gherkinDocument.feature.description,
                     name: featureName,
                     startTime: this.rpClient.helpers.now(),
                     type: 'SUITE'
@@ -120,11 +119,13 @@ class RPFormatter extends Formatter {
         const retryTest = Boolean(testCase.attempt);
         const testItem = await retry(async () => {
             const testItem = this.rpClient.startTestItem({
-                description: this.formatTags(testCase.pickle.tags),
+                description: this.rpConfig.tagsAsAttributes ? '' : this.formatTags(testCase.pickle.tags),
                 name: testCase.pickle.name,
                 startTime,
                 type: 'STEP',
-                attributes: [...attributes, ...this.prepareTags(testCase.pickle.tags) ],
+                attributes: [
+                    ...attributes,
+                    ...(this.rpConfig.tagsAsAttributes ? this.prepareTags(testCase.pickle.tags) : []) ],
                 retry: retryTest
             }, this.launchId, featureTempId);
             await testItem.promise;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qavajs/format-report-portal",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "description": "cucumber formatter for report portal",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qavajs/format-report-portal",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "cucumber formatter for report portal",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Before submitting this PR, please ensure that you have completed the following:

- [x] Updated the CHANGELOG.md.
- [x] Updated the README.md.
- [x] Updated the `packages.json` if necessary.
- [X] Checked that there aren't other open pull requests for the same issue/update.
- [X] Checked that your contribution follows the project's contribution guidelines.

## Description

I want to be able to have a choice to place tags either to attributes or to description.

### Related Issues

In follow-up to earlier release feature https://github.com/qavajs/format-report-portal/pull/33
